### PR TITLE
Feature/optimize multiuser bckrestore

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -6,9 +6,9 @@ set -e
 
 uid=$1
 shift
-pkg=$1
+pkgarg=$1
 
-if [ -z "$uid" -o -z "$pkg" ]; then
+if [ -z "$uid" -o -z "$pkgarg" ]; then
   echo "Usage $0 <uid> <pkg>"
   exit 0
 fi
@@ -22,11 +22,6 @@ pkgs="$*"
 uids="$uid"
 alluids=0
 
-# Backup all installed packages?
-if [ "$pkg" = "all" ]; then
-  pkgs="$(pm list packages | cut -f2 -d':')"
-fi
-
 if [ "$uid" = "all" ]; then
   alluids=1
   uids="$(pm list users | grep 'UserInfo' | cut -f1 -d':' | cut -f2 -d'{')"
@@ -35,6 +30,12 @@ fi
 for uid in $uids; do
   echo "Creating backup for uid $uid.."
   mkdir -p $base/data/$uid
+  
+  # Backup all installed packages?
+  if [ "$pkgarg" = "all" ]; then
+    pkgs="$(pm list packages --user "$uid" | cut -f2 -d':')"
+  fi
+
   for pkg in $pkgs; do
     if [ -f /data/app/$pkg-*/base.apk ]; then
       echo "  Backing up pkg $pkg.."

--- a/backup.sh
+++ b/backup.sh
@@ -65,15 +65,27 @@ for uid in $uids; do
     fi
   done
   echo "done."
+  # This is for old Android.
   if [ -f "/data/system/users/$uid/accounts.db" ]; then
     echo "Creating backup of accounts.db .."
-    cp /data/system/users/$uid/accounts.db $base/data/$uid/
+    tar -cf "$base/data/$uid/accounts.db.tar" "/data/system/users/$uid/accounts.db"
+    echo "done."
+  fi
+  # Newer Android (like Android 9).
+  if [ -f "/data/system_ce/$uid/accounts_ce.db" ]; then
+    echo "Creating backup of accounts_ce.db .."
+    tar -cf "$base/data/$uid/accounts_ce.db.tar" "/data/system_ce/$uid/accounts_ce.db"
+    echo "done."
+  fi
+  if [ -f "/data/system_de/$uid/accounts_de.db" ]; then
+    echo "Creating backup of accounts_de.db .."
+    tar -cf "$base/data/$uid/accounts_de.db.tar" "/data/system_de/$uid/accounts_de.db"
     echo "done."
   fi
 done
 if [ -f "/data/system/sync/accounts.xml" ]; then
-  echo "Creating backup of accounts.xml .."
-  cp /data/system/sync/accounts.xml $base/data/
+  echo "Creating backup of accounts.xml ..."
+  tar -cf "$base/data/accounts.xml.tar" "/data/system/sync/accounts.xml"
   echo "done."
 fi
 

--- a/restore.sh
+++ b/restore.sh
@@ -37,6 +37,11 @@ for uid in $uids; do
   echo "Restoring backup for uid $uid.."
   for pkg in $pkgs; do
     [ -z "$pkg" ] && ( echo "Missing pkg"; exit 1)
+    # Testing if for this user, data existed, or if app was installed but disabled.
+    if ( [ ! -f "$base/data/$uid/$pkg-user.tar" ] ) && ( [ ! -f "$base/data/$uid/$pkg.disabled" ] ) ; then
+      # The app didn't exist for the user (neither in enabled nor disabled form). Stop the current iteration and proceed to the next pkg.
+      continue 1
+    fi
     echo "  Restoring pkg $pkg.."
     if [ -f "$base/apks/$pkg.apk" ]; then
       if [ -z "$(pm list package $pkg)" ]; then


### PR DESCRIPTION
Modification:
1. backup.sh: Some app can be installed only for some user but not for user 0. This fixes it by list pkg per user.
2. backup.sh: accounts.db is not used anymore in Android 9. accounts_ce.db and accounts_de.db supersedes it. Using tar instead of cp to preserve rights.
3. restore.sh: restore only if it was installed for the user during backup, based on presence on data or .disabled file.